### PR TITLE
Replace exists() with existsSync() because it is deprecated.

### DIFF
--- a/lib/util/review-runner.js
+++ b/lib/util/review-runner.js
@@ -213,7 +213,7 @@ var FileContentWatcher = (function (_super) {
         this.fileRemovedSubscription = null;
     };
     FileContentWatcher.prototype.configureRunner = function () {
-        if (this.file.exists()) {
+        if (this.file.existsSync()) {
             this.activate();
         }
         else {

--- a/lib/util/review-runner.ts
+++ b/lib/util/review-runner.ts
@@ -275,7 +275,7 @@ class FileContentWatcher extends emissaryHelper.EmitterSubscriberBase implements
 	}
 
 	configureRunner():void {
-		if (this.file.exists()) {
+		if (this.file.existsSync()) {
 			this.activate();
 		} else {
 			this.deactivate();

--- a/package.json
+++ b/package.json
@@ -6,12 +6,12 @@
   "repository": "https://github.com/vvakame/language-review",
   "license": "MIT",
   "engines": {
-    "atom": "*",
+    "atom": ">=0.180.0",
     "node": "*"
   },
   "dependencies": {
     "review.js": "0.6.2",
-    "pathwatcher": "2.6.0",
+    "pathwatcher": "3.3.1",
     "color": "0.7.3",
     "emissary": "1.3.1",
     "text-buffer": "3.0.4",


### PR DESCRIPTION
This deprecation was introduced in pathwatcher 3.3.0:
https://github.com/atom/node-pathwatcher/commit/6d6f2666dabe581111808a8cbe856d8429f0f21b

Atom started pulling in pathwatcher 3.3.1 in version 0.180.0:
https://github.com/atom/atom/commit/c260a29434547493d5f22508e2afd2da96f13f40