### PR TITLE
古いAtomのAPIの利用によりプレビューまわりで内部エラーが発生していたのを修正

### DIFF
--- a/dtsm.json
+++ b/dtsm.json
@@ -9,16 +9,16 @@
   "bundle": "typings/bundle.d.ts",
   "dependencies": {
     "atom/atom.d.ts": {
-      "ref": "230b346dad577c91af8db9f0a1db26697d2dd5bd"
+      "ref": "4502a738b25345b63a24d4ff4695cd4a63f0ec65"
     },
     "node/node.d.ts": {
-      "ref": "230b346dad577c91af8db9f0a1db26697d2dd5bd"
+      "ref": "4502a738b25345b63a24d4ff4695cd4a63f0ec65"
     },
     "es6-promise/es6-promise.d.ts": {
-      "ref": "230b346dad577c91af8db9f0a1db26697d2dd5bd"
+      "ref": "4502a738b25345b63a24d4ff4695cd4a63f0ec65"
     },
     "jasmine/jasmine.d.ts": {
-      "ref": "230b346dad577c91af8db9f0a1db26697d2dd5bd"
+      "ref": "4502a738b25345b63a24d4ff4695cd4a63f0ec65"
     }
   },
   "link": {

--- a/lib/language-review.js
+++ b/lib/language-review.js
@@ -92,7 +92,7 @@ var Controller = (function () {
         var uri = V.protocol + "//" + V.previewHost + "/" + editor.id;
         var previewPane = atom.workspace.paneForURI(uri);
         if (previewPane) {
-            previewPane.destroyItem(previewPane.itemForUri(uri));
+            previewPane.destroyItem(previewPane.itemForURI(uri));
             return;
         }
         var previousActivePane = atom.workspace.getActivePane();
@@ -123,7 +123,7 @@ var Controller = (function () {
         var uri = V.protocol + "//" + V.syntaxListHost + "/" + editor.id;
         var previewPane = atom.workspace.paneForURI(uri);
         if (previewPane) {
-            previewPane.destroyItem(previewPane.itemForUri(uri));
+            previewPane.destroyItem(previewPane.itemForURI(uri));
             return;
         }
         var previousActivePane = atom.workspace.getActivePane();

--- a/lib/language-review.ts
+++ b/lib/language-review.ts
@@ -110,7 +110,7 @@ class Controller {
 		var previewPane = atom.workspace.paneForURI(uri);
 
 		if (previewPane) {
-			previewPane.destroyItem(previewPane.itemForUri(uri));
+			previewPane.destroyItem(previewPane.itemForURI(uri));
 			return;
 		}
 
@@ -149,7 +149,7 @@ class Controller {
 		var previewPane = atom.workspace.paneForURI(uri);
 
 		if (previewPane) {
-			previewPane.destroyItem(previewPane.itemForUri(uri));
+			previewPane.destroyItem(previewPane.itemForURI(uri));
 			return;
 		}
 

--- a/lib/typings/atom/atom.d.ts
+++ b/lib/typings/atom/atom.d.ts
@@ -7,7 +7,6 @@ declare module AtomCore {
         addOpener(callback: (url: string, options?: any) => any): IDisposable;
         getActiveTextEditor(): IEditor;
         getTextEditors(): IEditor[];
-        paneForURI: (uri: string) => IPane;
     }
     interface IPackageManager {
         onDidActivateInitialPackages(callback: () => void): IDisposable;


### PR DESCRIPTION
 - DTのatom.d.ts定義が更新されたのを取り込み
 - 新しいatom.d.tsと衝突してコンパイル失敗するエントリをlib/下のatom.d.tsから削除
 - 新しいatom.d.tsでビルドするとエラーとなるts数カ所を修正