### PR TITLE
3レベル以外でコラム構文がシンタックスハイライト効いていなかったのを直した

### DIFF
--- a/grammars/review.json
+++ b/grammars/review.json
@@ -33,7 +33,7 @@
                 }
             },
             "name": "column.review.begin",
-            "match": "(^={3}\\[(column)\\])\\s(.*)"
+            "match": "(^={1,4}\\[(column)\\])\\s(.*)"
         },
         {
             "comment": "Column ===[/column]",
@@ -46,7 +46,7 @@
                 }
             },
             "name": "column.review.end",
-            "match": "(^={3}\\[/(column)\\])"
+            "match": "(^={1,4}\\[/(column)\\])"
         },
         {
             "comment": "Bullet point * ",


### PR DESCRIPTION
https://github.com/kmuto/review/blob/master/doc/format.ja.md#%E3%82%B3%E3%83%A9%E3%83%A0%E3%81%AA%E3%81%A9 によると`節や項の見出しに [column] を追加するとコラムのキャプションになります。`で、コード的にも https://github.com/kmuto/review/blob/master/lib/review/book/index.rb#L308 という具合でした。

つまり、3段階以外の見出しでもコラムは有効なのでシンタックスハイライトもするのが正しいです(review.js側では特にこの制約無いので出力結果は現状で問題ありません)