### PR TITLE
見出しレベルは4(段)ではなく5(小段)まで使えるのでサポートするようにした

### DIFF
--- a/grammars/review.json
+++ b/grammars/review.json
@@ -33,7 +33,7 @@
                 }
             },
             "name": "column.review.begin",
-            "match": "(^={3}\\[(column)\\])\\s(.*)"
+            "match": "(^={1,4}\\[(column)\\])\\s(.*)"
         },
         {
             "comment": "Column ===[/column]",
@@ -46,7 +46,7 @@
                 }
             },
             "name": "column.review.end",
-            "match": "(^={3}\\[/(column)\\])"
+            "match": "(^={1,4}\\[/(column)\\])"
         },
         {
             "comment": "Bullet point * ",

--- a/grammars/review.json
+++ b/grammars/review.json
@@ -17,7 +17,7 @@
                 }
             },
             "name": "patagraph.review",
-            "match": "(^={1,4}(\\{([^\\}]+)\\})?)\\s(.*)"
+            "match": "(^={1,5}(\\{([^\\}]+)\\})?)\\s(.*)"
         },
         {
             "comment": "Column ===[column]",
@@ -33,7 +33,7 @@
                 }
             },
             "name": "column.review.begin",
-            "match": "(^={1,4}\\[(column)\\])\\s(.*)"
+            "match": "(^={1,5}\\[(column)\\])\\s(.*)"
         },
         {
             "comment": "Column ===[/column]",
@@ -46,7 +46,7 @@
                 }
             },
             "name": "column.review.end",
-            "match": "(^={1,4}\\[/(column)\\])"
+            "match": "(^={1,5}\\[/(column)\\])"
         },
         {
             "comment": "Bullet point * ",


### PR DESCRIPTION
コラム構文のシンタックスハイライトポリシーを直した状態が前提となるので、本PRは https://github.com/vvakame/language-review/pull/21 に依存します。

https://github.com/kmuto/review/blob/master/doc/format.ja.md#%E7%AB%A0%E7%AF%80%E9%A0%85%E6%AE%B5%E8%A6%8B%E5%87%BA%E3%81%97 によると、Re:VIEWの仕様では5レベルまでの見出しをサポートしているので、シンタックスハイライトの対象も広げました。