### PR TITLE
正しくコメントアウトできるよう修正

### DIFF
--- a/settings/language-review.cson
+++ b/settings/language-review.cson
@@ -1,3 +1,3 @@
-'.re':
+'.source.review':
   'editor':
-    'commentStart': '+@+'
+    'commentStart': '#@#'


### PR DESCRIPTION
ctrl(cmd)+/でコメントアウトした際に正しく動作しない問題を修正しました。